### PR TITLE
Better django parity, validation bypass

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -11,6 +11,9 @@ main () {
     (
         cd "$TESTS_DIR" || exit 1
 
+        # Delete the HTML coverage report directory.
+        rm -rf htmlcov/
+
         # Run the pytest suite.
         poetry run pytest "$@"
     )

--- a/flexible_forms/fields.py
+++ b/flexible_forms/fields.py
@@ -153,11 +153,6 @@ class FlexibleField:
             field_values=field_values,
         )
 
-        # Any fields with "None" as an option in their choices can never be
-        # required.
-        if any(c[0] is None for c in getattr(form_field, "choices", [])):
-            form_field.required = False
-
         return form_field
 
     @classmethod
@@ -232,7 +227,7 @@ class FlexibleField:
                 form_field,
                 "_modifiers",
                 {
-                    **getattr(form_field, "_applied_modifiers", {}),
+                    **getattr(form_field, "_modifiers", {}),
                     attribute: expression_value,
                 },
             )
@@ -401,8 +396,8 @@ class YesNoRadioField(FlexibleField):
     form_field_class = form_fields.TypedChoiceField
     form_field_options = {
         "choices": (
-            (True, "Yes"),
-            (False, "No"),
+            ("True", "Yes"),
+            ("False", "No"),
         ),
         "coerce": lambda v: True if v in ("True", True) else False,
     }
@@ -418,9 +413,9 @@ class YesNoUnknownRadioField(FlexibleField):
     form_field_class = form_fields.TypedChoiceField
     form_field_options = {
         "choices": (
-            (True, "Yes"),
-            (False, "No"),
-            (None, "Unknown"),
+            ("True", "Yes"),
+            ("False", "No"),
+            ("None", "Unknown"),
         ),
         "coerce": lambda v: (
             True if v in ("True", True) else False if v in ("False", False) else None
@@ -439,8 +434,8 @@ class YesNoSelectField(FlexibleField):
     form_field_class = form_fields.TypedChoiceField
     form_field_options = {
         "choices": (
-            (True, "Yes"),
-            (False, "No"),
+            ("True", "Yes"),
+            ("False", "No"),
         ),
         "coerce": lambda v: True if v in ("True", True) else False,
     }
@@ -456,9 +451,9 @@ class YesNoUnknownSelectField(FlexibleField):
     form_field_class = form_fields.TypedChoiceField
     form_field_options = {
         "choices": (
-            (True, "Yes"),
-            (False, "No"),
-            (None, "Unknown"),
+            ("True", "Yes"),
+            ("False", "No"),
+            ("None", "Unknown"),
         ),
         "coerce": lambda v: (
             True if v in ("True", True) else False if v in ("False", False) else None

--- a/flexible_forms/forms.py
+++ b/flexible_forms/forms.py
@@ -2,14 +2,14 @@
 """Forms that power the flexible_forms module."""
 
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, cast
+from typing import Any, Dict, Mapping, Optional, cast
 
 from django import forms
 from django.core.files.base import File
 from django.forms.fields import FileField
+from django.forms.models import ModelChoiceIteratorValue  # type: ignore
 
-if TYPE_CHECKING:  # pragma: no cover
-    from flexible_forms.models import BaseRecord
+from flexible_forms.models import BaseRecord
 
 
 class BaseRecordForm(forms.ModelForm):
@@ -21,6 +21,7 @@ class BaseRecordForm(forms.ModelForm):
 
     class Meta:
         fields = ("_form",)
+        model: "BaseRecord"
 
     def __init__(
         self,
@@ -30,21 +31,37 @@ class BaseRecordForm(forms.ModelForm):
         initial: Optional[Mapping[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        initial_data = {
-            **(instance._data if instance else {}),
-            **(initial or {}),
-        }
+        opts = self._meta  # type: ignore
+
+        # Extract the form definition from the given data, the instance, or the
+        # initial values.
+        self._form = (
+            (data or {}).get("_form")
+            or getattr(instance, "_form", None)
+            or (initial or {}).get("_form")
+        )
+
+        if isinstance(self._form, ModelChoiceIteratorValue):
+            self._form = self._form.instance
+
+        # If no record instance was given, create a new (empty) one and use its
+        # data for the initial form values.
+        instance = instance or opts.model(_form=self._form)
+        initial = {**instance._data, **(initial or {}), "_form": self._form}
 
         super().__init__(
-            data=data, files=files, instance=instance, initial=initial_data, **kwargs
+            data=data, files=files, instance=instance, initial=initial, **kwargs
         )
+
+        if self._form:
+            self.fields["_form"].disabled = True
 
     def clean(self) -> Dict[str, Any]:
         """Clean the form data before saving."""
         cleaned_data = super().clean()
 
         for key, value in cleaned_data.items():
-            field = {**self.base_fields, **self.fields}.get(key)
+            field = self.fields.get(key)
 
             # Time-only values cannot be timezone aware, so we remove the
             # timezone if one is given.

--- a/flexible_forms/forms.py
+++ b/flexible_forms/forms.py
@@ -78,13 +78,15 @@ class BaseRecordForm(forms.ModelForm):
 
         return cleaned_data
 
-    def save(self, commit: bool = True) -> "BaseRecord":
+    def save(self, commit: bool = True, validate: bool = True) -> "BaseRecord":
         """Save the form data to a Record.
 
         Maps the cleaned form data into the Record's _data field.
 
         Args:
             commit: If True, persists the data to the database.
+            validate: If False, attempts to persist the record even if
+                validation is failing.
 
         Returns:
             instance: The Record model instance.
@@ -93,4 +95,9 @@ class BaseRecordForm(forms.ModelForm):
         for field_name in self.changed_data:
             setattr(self.instance, field_name, self.cleaned_data[field_name])
 
-        return cast("BaseRecord", super().save(commit=commit))
+        if commit and not validate:
+            self.instance.save()
+        else:
+            super().save(commit=commit)
+
+        return cast("BaseRecord", self.instance)

--- a/flexible_forms/models.py
+++ b/flexible_forms/models.py
@@ -27,7 +27,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models, transaction
 from django.db.models.manager import BaseManager
 from django.db.models.query import Prefetch
-from django.forms.fields import FileField
+from django.forms.widgets import Widget
 from django.utils.datastructures import MultiValueDict
 from django.utils.functional import cached_property
 from django.utils.text import slugify
@@ -136,6 +136,19 @@ class BaseForm(FlexibleBaseModel):
 
         super().save(*args, **kwargs)
 
+    @property
+    def initial_values(self) -> "MultiValueDict[str, Any]":
+        """Return a mapping of initial values for the form."""
+        return MultiValueDict(
+            {
+                **{
+                    f.name: f.initial if isinstance(f.initial, list) else [f.initial]
+                    for f in self.fields.all()
+                },
+                "_form": [self],
+            }
+        )
+
     def as_django_form(
         self,
         data: Optional[Mapping[str, Any]] = None,
@@ -160,74 +173,75 @@ class BaseForm(FlexibleBaseModel):
         Returns:
             BaseRecordForm: A configured BaseRecordForm (a Django ModelForm instance).
         """
-        if isinstance(data, MultiValueDict):
-            data = data.dict()
-
-        if isinstance(files, MultiValueDict):
-            files = files.dict()
-
-        if isinstance(initial, MultiValueDict):
-            initial = initial.dict()
-
-        # Derive the Record model from the relationship field.
-        Record = self._flexible_model_for(BaseRecord)
-
-        instance = instance or Record(_form=self)  # type: ignore
-        data = cast(Mapping[str, Any], {**(data or instance._data), "_form": self.pk})
-        files = cast(Mapping[str, Any], files or {})
-        initial = cast(Mapping[str, Any], {**(initial or {}), "_form": self.pk})
-
-        class_name = self.name.title().replace("_", "")
-        form_class_name = f"{class_name}Form"
         all_fields = self.fields.all()
-        field_values = {
-            **instance._data,
-            **({k: data.get(k) for k in data.keys()}),
-            **({k: files.get(k) for k in files.keys()}),
-        }
 
-        # Generate the initial list of fields that comprise the form.
-        form_fields = {f.name: f.as_form_field() for f in all_fields}
+        # Build a MultiValueDict containing all field values. This combines all
+        # of the form data into a single structure that will be used when
+        # evaluating expressions against the form state.
+        form_state: MultiValueDict[str, Any] = self.initial_values
+        form_state.update(initial or {})
+        form_state.update(instance._data if instance else {})
+        form_state.update(data or {})
+        form_state.update(files or {})
 
         # Normalize the field values to ensure they are all cast to their
         # appropriate types (as defined by their corresponding form fields).
+        form_fields: MutableMapping[str, forms.Field] = {
+            f.name: f.as_form_field() for f in all_fields
+        }
         for field_name, form_field in form_fields.items():
-            field_value = field_values.get(field_name)
-            if isinstance(form_field, FileField) and field_value is False:
-                field_value = None
-            # HACK: If the widget allows for multiple selections, make sure the
-            # value is a list. This method should be refactored to use
-            # MultiValueDict structures instead.
-            if getattr(form_field.widget, "allow_multiple_selected", False):
-                field_value = [field_value]
-            field_values[field_name] = form_field.to_python(field_value)
+            field_widget = cast(Widget, form_field.widget)
+            field_value = field_widget.value_from_datadict(
+                data=form_state,  # type: ignore
+                files=form_state,
+                name=field_name,
+            )
+            # Try to perform as much of the value coercion process as possible
+            # while attempting to avoid running expensive validators.
+            try:
+                field_value = form_field.to_python(field_value)
+                if callable(getattr(form_field, "_coerce", None)):
+                    field_value = form_field._coerce(field_value)  # type: ignore
+            except ValidationError:
+                pass
+            form_state[field_name] = field_value
 
         # Regenerate the form fields, this time taking the field values into
         # account in order to inform any dynamic behaviors.
-        form_fields = {
-            f.name: f.as_form_field(
-                field_values=field_values,
-            )
-            for f in all_fields
-        }
+        form_fields = {}
+        for field in all_fields:
+            form_field = field.as_form_field(field_values=form_state)
+            form_fields[field.name] = form_field
 
-        # Dynamically generate a form class containing all of the fields.
-        # The BaseRecordForm is imported inline to prevent a circular import.
+        RecordModel = self._flexible_model_for(BaseRecord)
+
+        # Import the form class inline to prevent a circular import.
         from flexible_forms.forms import BaseRecordForm
 
+        form_name = f"{self.name.title().replace('_', '')}Form"
         form_class: Type[BaseRecordForm] = type(
-            form_class_name,
+            form_name,
             (BaseRecordForm,),
             {
                 "__module__": self.__module__,
-                "Meta": type("Meta", (BaseRecordForm.Meta,), {"model": Record}),
+                "Meta": type(
+                    "Meta",
+                    (BaseRecordForm.Meta,),
+                    {"model": RecordModel},
+                ),
                 **form_fields,
             },
         )
 
+        initial = {"_form": self, **(initial or {})}
+
         # Create a form instance from the form class and the passed parameters.
         form_instance = form_class(
-            data=data, files=files, instance=instance, initial=initial, **kwargs
+            data=data,
+            files=files,
+            instance=instance,
+            initial=initial,
+            **kwargs,
         )
 
         return form_instance
@@ -269,10 +283,11 @@ class BaseField(FlexibleBaseModel):
         help_text="If True, requires a value be present in the field.",
     )
 
-    initial = models.TextField(
+    initial = JSONField(
         blank=True,
-        default="",
+        null=True,
         help_text=("The default value if no value is given during initialization."),
+        encoder=DjangoJSONEncoder,
     )
 
     field_type = models.TextField(
@@ -567,7 +582,7 @@ class BaseRecord(FlexibleBaseModel):
         abstract = True
 
     def __str__(self) -> str:
-        return f"Record {self.pk} (_form_id={self._form_id if self._form else None})"
+        return f"Record {self.pk} (_form_id={self._form_id})"
 
     def __init__(
         self, *args: Any, _form: Optional[BaseForm] = None, **kwargs: Any
@@ -575,6 +590,21 @@ class BaseRecord(FlexibleBaseModel):
         super().__init__(*args, _form=_form, **kwargs)
         self._staged_changes = {}
         self._initialized = True
+
+    def as_django_form(self, *args: Any, **kwargs: Any) -> "BaseRecordForm":
+        """Create a Django form from the record.
+
+        Uses `self` as the `instance` argument to as_django_form()`
+
+        Args:
+            args: Passed to super.
+            kwargs: Passed to super.
+
+        Returns:
+            BaseRecordForm: A configured Django form for the record.
+        """
+        kwargs = {"instance": self, **kwargs}
+        return self._form.as_django_form(*args, **kwargs)
 
     @cached_property
     def _fields(self) -> Mapping[str, BaseField]:

--- a/flexible_forms/models.py
+++ b/flexible_forms/models.py
@@ -614,6 +614,8 @@ class BaseRecord(FlexibleBaseModel):
             Mapping[str, BaseField]: A mapping of Field instances by their
                 names.
         """
+        if not hasattr(self, "_form"):
+            return {}
         return {f.name: f for f in self._form.fields.all()}
 
     @cached_property

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,6 +207,14 @@ sqlparse = ">=0.2.0"
 
 [[package]]
 category = "dev"
+description = "Extensions for Django"
+name = "django-extensions"
+optional = false
+python-versions = ">=3.5"
+version = "3.0.9"
+
+[[package]]
+category = "dev"
 description = "Django admin classes that allow for nested inlines"
 name = "django-nested-admin"
 optional = false
@@ -930,7 +938,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "58a3e41fc5d18d41c2008831c32d511a22c72b062a80c30e5f040806e8ed8ec9"
+content-hash = "80fda43f993c097cd4d42af3bac00387a5388137c451c1983c477c5488f667c2"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -1037,6 +1045,10 @@ django = [
 django-debug-toolbar = [
     {file = "django-debug-toolbar-3.0.tar.gz", hash = "sha256:23129b4f771605c7ccf8733cc53558a68c5d463d60cdc83408d34b713acf4f5f"},
     {file = "django_debug_toolbar-3.0-py3-none-any.whl", hash = "sha256:7c9bf93eabb1e745fe1fca830242d49f3c839d35163e5b53914009ed111209b1"},
+]
+django-extensions = [
+    {file = "django-extensions-3.0.9.tar.gz", hash = "sha256:6809c89ca952f0e08d4e0766bc0101dfaf508d7649aced1180c091d737046ea7"},
+    {file = "django_extensions-3.0.9-py3-none-any.whl", hash = "sha256:dc663652ac9460fd06580a973576820430c6d428720e874ae46b041fa63e0efa"},
 ]
 django-nested-admin = [
     {file = "django-nested-admin-3.3.2.tar.gz", hash = "sha256:7ec58af67107e6d7b2d0fd4fe03629eff8f7957c4aef5033c4700da1bd2d7870"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ sphinx = "^3.2.1"
 sphinx-autoapi = "^1.5.0"
 pytest-mock = "^3.3.1"
 django-debug-toolbar = "^3.0"
+django-extensions = "^3.0.9"
 
 [tool.dephell.main]
 from = {format = "poetry", path = "pyproject.toml"}

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "dev": [
             "autopep8==1.*,>=1.5.4", "black==20.*,>=20.8.0.b1",
             "darglint==1.*,>=1.5.4", "django-debug-toolbar==3.*,>=3.0.0",
+            "django-extensions==3.*,>=3.0.9",
             "django-nested-admin==3.*,>=3.3.2", "django-stubs==1.*,>=1.5.0",
             "docformatter==1.*,>=1.3.1", "factory-boy==3.*,>=3.0.1",
             "hypothesis[django]==5.*,>=5.26.0", "isort==5.*,>=5.4.2",

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "nested_admin",
     "debug_toolbar",
+    "django_extensions",
     "flexible_forms",
     "test_app.apps.TestAppConfig",
 ]


### PR DESCRIPTION
* Changes `as_django_form()` behavior to be closer to native Django forms by allowing forms to be unbound if no data or files are passed explicitly. This allows for some performance optimizations under the hood in Django forms (e.g., not validating unnecessarily when the form is unbound).
* Support `django_form.save(validate=False)`, which allows forms to attempt to bypass validation to persist a partial record (good for staging data).
* Minor cleanup and fixes for coerced field types.
* Adds `django-extensions` to the test app for easier development and debugging.